### PR TITLE
Refactor dashboard tiles into separate modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,6 @@
   <link rel="stylesheet" href="css/layout.css">
   <link rel="stylesheet" href="css/tiles.css">
 
-
 </head>
 <body>
   <div id="scrim" class="scrim" tabindex="-1" aria-hidden="true"></div>
@@ -229,10 +228,6 @@
       </div>
     </div>
   </div>
-
-  <script src="https://www.gstatic.com/firebasejs/9.15.0/firebase-app-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/9.15.0/firebase-auth-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/9.15.0/firebase-firestore-compat.js"></script>
 
   <script type="module" src="js/main.js"></script>
 </body>

--- a/js/main.js
+++ b/js/main.js
@@ -1,31 +1,27 @@
 // app.js (ES module)
 import { renderTiles, initTileSystem } from './tiles.js';
 
-// Firebase v9+ (modular)
-import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js';
-import {
-  getAuth,
-  onAuthStateChanged,
-  signOut as fbSignOut,
-  signInWithEmailAndPassword,
-  createUserWithEmailAndPassword,
-  updateProfile,
-  GoogleAuthProvider,
-  signInWithPopup
-} from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
-import {
-  getFirestore,
-  collection,
-  doc,
-  addDoc,
-  updateDoc,
-  deleteDoc,
-  onSnapshot,
-  getDocs,
-  query,
-  orderBy,
-  serverTimestamp
-} from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js';
+// Firebase (loaded dynamically to allow graceful offline fallback)
+let initializeApp;
+let getAuth;
+let onAuthStateChanged;
+let fbSignOut;
+let signInWithEmailAndPassword;
+let createUserWithEmailAndPassword;
+let updateProfile;
+let GoogleAuthProvider;
+let signInWithPopup;
+let getFirestore;
+let collection;
+let doc;
+let addDoc;
+let updateDoc;
+let deleteDoc;
+let onSnapshot;
+let getDocs;
+let query;
+let orderBy;
+let serverTimestamp;
 
 const firebaseConfig = {
   apiKey: "AIzaSyC1qN3ksU0uYhXRXYNmYlmGX0iyUa-BJFQ",
@@ -37,10 +33,11 @@ const firebaseConfig = {
   measurementId: "G-KQX4BQ71VK"
 };
 
-// Initialize Firebase
-const app = initializeApp(firebaseConfig);
-const auth = getAuth(app);
-const db = getFirestore(app);
+// Firebase state (populated asynchronously)
+let app = null;
+let auth = null;
+let db = null;
+let firebaseReady = false;
 
 // Constants
 const MAX_RECENT_ROWS = 10;
@@ -69,10 +66,56 @@ let instructionsModal, closeInstructionsBtn, logoCard, manifestoCard, supportCar
 let authSection, loginBtn, signupBtn, authSubmit, authActions, signupFields, authTitle, authToggle;
 let authEmail, authPassword, authUsername, authRePassword;
 
+const loadFirebaseModules = async () => {
+  try {
+    const [appModule, authModule, firestoreModule] = await Promise.all([
+      import('https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js'),
+      import('https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js'),
+      import('https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js')
+    ]);
+
+    ({ initializeApp } = appModule);
+    ({
+      getAuth,
+      onAuthStateChanged,
+      signOut: fbSignOut,
+      signInWithEmailAndPassword,
+      createUserWithEmailAndPassword,
+      updateProfile,
+      GoogleAuthProvider,
+      signInWithPopup
+    } = authModule);
+    ({
+      getFirestore,
+      collection,
+      doc,
+      addDoc,
+      updateDoc,
+      deleteDoc,
+      onSnapshot,
+      getDocs,
+      query,
+      orderBy,
+      serverTimestamp
+    } = firestoreModule);
+
+    app = initializeApp(firebaseConfig);
+    auth = getAuth(app);
+    db = getFirestore(app);
+    firebaseReady = true;
+  } catch (error) {
+    console.warn('Firebase modules failed to load. Running in offline mode.', error);
+  }
+};
+
 // DOM Content Loaded - Initialize element references
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
   // Main app elements
   appContent = document.getElementById('app-content');
+
+  // Render dashboard tiles before querying for tile-specific elements
+  renderTiles(appContent);
+
   nameInput = document.getElementById('food-name');
   dairyCheckbox = document.getElementById('contains-dairy');
   outsideMealsCheckbox = document.getElementById('outside-meals');
@@ -172,6 +215,9 @@ document.addEventListener('DOMContentLoaded', () => {
   
   // Set up event listeners after elements are available
   setupEventListeners(tileSystem);
+
+  await loadFirebaseModules();
+  initializeAuthListener();
 });
 
 // --- Translations ---
@@ -198,16 +244,16 @@ const translations = {
     statOutsideMeals: 'Outside of mealtimes',
     statLastEntry: 'Last entry',
     quickAddTitle: 'Quick add',
-    quickAddHint: 'Log what you're eating right now—no pressure, no judgement.',
+    quickAddHint: 'Log what you’re eating right now—no pressure, no judgement.',
     growthTitle: 'Room to grow',
     growthCopy: 'This space is ready for habits, reflections, or whatever else you need next.',
-    supportBadge: 'Keep McFatty's free',
+    supportBadge: 'Keep McFatty’s free',
     supportTitle: 'Support us',
     supportCopy: 'Chip in to cover hosting and keep the tracker open for everyone.',
     recentLogTitle: 'Recent log',
     organizeTiles: 'Organize tiles',
     doneOrganizing: 'Done',
-    reorderHint: 'Drag tiles to reorder. Tap Done when you're finished.',
+    reorderHint: 'Drag tiles to reorder. Tap Done when you’re finished.',
     logSearchLabel: 'Search log',
     logSearchPlaceholder: 'Search entries',
     filterGroupLabel: 'Filters',
@@ -223,7 +269,7 @@ const translations = {
     addBtn: 'Add to log',
     dairyLabel: 'Contains dairy',
     outsideMealsLabel: 'Outside of mealtimes',
-    logTitle: 'Today's log',
+    logTitle: 'Today’s log',
     exportBtn: 'Export',
     thItem: 'Item',
     thTime: 'Time',
@@ -255,7 +301,7 @@ const translations = {
     passwordLabel: 'Password',
     usernameLabel: 'Username',
     rePasswordLabel: 'Re-type Password',
-    installSuccess: 'App installed! Find McFatty's on your home screen.',
+    installSuccess: 'App installed! Find McFatty’s on your home screen.',
     installDismissed: 'Install dismissed.',
     yes: 'Yes',
     no: 'No',
@@ -266,6 +312,7 @@ const translations = {
     authMissingFields: 'Please enter an email and password.',
     authMissingUsername: 'Please choose a username.',
     authPasswordMismatch: 'Passwords do not match.',
+    authUnavailable: 'Authentication is currently unavailable. Please try again later.',
     addError: 'Sorry, there was an error adding your entry.',
     deleteError: 'Sorry, there was an error removing your entry.',
     updateError: 'Sorry, there was an error updating your entry.',
@@ -294,9 +341,9 @@ const translations = {
     manifestoTitle: 'McFettys Manifest',
     manifestoP1: 'Bei McFettys Food Tracker geht es nicht um Kalorien, Einschränkungen oder Schuldgefühle. Wenn du Chips willst, iss sie. Keine Scham, keine Bestrafung. Schreib es einfach auf. Das Aufzeichnen ohne Urteil ist der entscheidende Akt.',
     manifestoP2: 'Diese App ist kostenlos. Keine Abonnements, keine Upsells, keine Lifestyle-Pakete. Wir lehnen die Idee ab, dass uns Essen und Gesundheit zurückverkauft werden sollten. Essen sollte kein Geschäftsmodell sein.',
-    manifestoP3: 'Stattdessen hilft Ihnen McFatty's, innezuhalten, auf Ihren Körper zu hören und Ihre Gewohnheiten zu bemerken. Bewusst oder unbewusst ermöglicht Ihnen das einfache Protokollieren, Muster zu erkennen und Ihre Beziehung zum Essen langsam zu verändern. Veränderung sollte kein Wettlauf sein. Sie sollte langsam, sanft und in Respekt für Ihre Entscheidungen verwurzelt sein.',
+    manifestoP3: 'Stattdessen hilft Ihnen McFatty’s, innezuhalten, auf Ihren Körper zu hören und Ihre Gewohnheiten zu bemerken. Bewusst oder unbewusst ermöglicht Ihnen das einfache Protokollieren, Muster zu erkennen und Ihre Beziehung zum Essen langsam zu verändern. Veränderung sollte kein Wettlauf sein. Sie sollte langsam, sanft und in Respekt für Ihre Entscheidungen verwurzelt sein.',
     manifestoP4: 'Wir sind gegen Kreisläufe von Schuld, Scham und unmöglichen Versprechungen. Wir werden den als Selbstfürsorge getarnten Konsum nicht feiern. Wir glauben, die radikale Wahl ist, zu verlangsamen, auf sich selbst zu hören und zu Ihren eigenen Bedingungen zu essen.',
-    manifestoP5: 'Die App wird immer kostenlos sein. Es gibt einen Spenden-Button für diejenigen, die unterstützen möchten, denn obwohl die Welt frei sein sollte, ist sie es nicht. Aber McFatty's wird niemals von Ihrer Schuld profitieren.',
+    manifestoP5: 'Die App wird immer kostenlos sein. Es gibt einen Spenden-Button für diejenigen, die unterstützen möchten, denn obwohl die Welt frei sein sollte, ist sie es nicht. Aber McFatty’s wird niemals von Ihrer Schuld profitieren.',
     donateBtn: 'Spenden',
     welcome: 'Willkommen',
     welcomeBack: 'Willkommen zurück',
@@ -309,7 +356,7 @@ const translations = {
     quickAddHint: 'Protokolliere, was du gerade isst – ohne Druck, ohne Urteil.',
     growthTitle: 'Platz für mehr',
     growthCopy: 'Hier ist Raum für Gewohnheiten, Reflexionen oder alles, was du als Nächstes brauchst.',
-    supportBadge: 'McFatty's kostenlos halten',
+    supportBadge: 'McFatty’s kostenlos halten',
     supportTitle: 'Unterstütze uns',
     supportCopy: 'Hilf mit, die Hosting-Kosten zu decken und den Tracker für alle offen zu halten.',
     recentLogTitle: 'Aktuelles Protokoll',
@@ -363,7 +410,7 @@ const translations = {
     passwordLabel: 'Passwort',
     usernameLabel: 'Benutzername',
     rePasswordLabel: 'Passwort erneut eingeben',
-    installSuccess: 'App installiert! McFatty's ist jetzt auf deinem Startbildschirm.',
+    installSuccess: 'App installiert! McFatty’s ist jetzt auf deinem Startbildschirm.',
     installDismissed: 'Installation abgebrochen.',
     yes: 'Ja',
     no: 'Nein',
@@ -374,6 +421,7 @@ const translations = {
     authMissingFields: 'Bitte E-Mail und Passwort eingeben.',
     authMissingUsername: 'Bitte einen Benutzernamen wählen.',
     authPasswordMismatch: 'Passwörter stimmen nicht überein.',
+    authUnavailable: 'Die Anmeldung ist derzeit nicht verfügbar. Bitte versuche es später erneut.',
     addError: 'Beim Hinzufügen deines Eintrags ist ein Fehler aufgetreten.',
     deleteError: 'Beim Entfernen deines Eintrags ist ein Fehler aufgetreten.',
     updateError: 'Beim Aktualisieren deines Eintrags ist ein Fehler aufgetreten.',
@@ -523,7 +571,7 @@ const setLanguage = (newLang) => {
     el.placeholder = getTranslation(key);
   });
 
-  const user = auth.currentUser;
+  const user = firebaseReady && auth ? auth.currentUser : null;
   if (user) {
     const isNewUser = user.metadata.creationTime === user.metadata.lastSignInTime;
     const welcomeTextKey = isNewUser ? 'welcome' : 'welcomeBack';
@@ -866,6 +914,11 @@ const handleAuthSubmit = async () => {
     }
   }
 
+  if (!firebaseReady || !auth || typeof signInWithEmailAndPassword !== 'function' || typeof createUserWithEmailAndPassword !== 'function') {
+    alert(getTranslation('authUnavailable'));
+    return;
+  }
+
   authSubmit.disabled = true;
   try {
     if (isLoginMode) {
@@ -893,6 +946,10 @@ const handleAuthSubmit = async () => {
 const signOut = (event) => {
   if (event) {
     event.preventDefault();
+  }
+  if (!firebaseReady || !auth || typeof fbSignOut !== 'function') {
+    console.warn('Sign out unavailable: Firebase not initialized.');
+    return;
   }
   fbSignOut(auth).catch((error) => {
     console.error('Error signing out:', error);
@@ -958,6 +1015,10 @@ const setupEventListeners = (tileSystem) => {
 
   if (googleSigninBtn) {
     googleSigninBtn.addEventListener('click', () => {
+      if (!firebaseReady || !auth || typeof GoogleAuthProvider !== 'function' || typeof signInWithPopup !== 'function') {
+        alert(getTranslation('authUnavailable'));
+        return;
+      }
       const provider = new GoogleAuthProvider();
       signInWithPopup(auth, provider).catch(err => {
         alert(`${getTranslation('authErrorPrefix')} ${err.message}`);
@@ -1103,8 +1164,7 @@ const setupEventListeners = (tileSystem) => {
   }
 };
 
-// Auth state listener
-onAuthStateChanged(auth, user => {
+const handleAuthStateChange = (user) => {
   if (unsubscribe) { unsubscribe(); unsubscribe = null; }
 
   const loggedIn = !!user;
@@ -1146,7 +1206,15 @@ onAuthStateChanged(auth, user => {
     setAuthMode(true);
     resetAuthFields();
   }
-});
+};
+
+const initializeAuthListener = () => {
+  if (firebaseReady && typeof onAuthStateChanged === 'function' && auth) {
+    onAuthStateChanged(auth, handleAuthStateChange);
+  } else {
+    handleAuthStateChange(null);
+  }
+};
 
 // Service Worker
 if ('serviceWorker' in navigator) {

--- a/js/tiles.js
+++ b/js/tiles.js
@@ -1,192 +1,22 @@
-const tileDefinitions = [
-  {
-    id: 'logo',
-    elementId: 'logo-card',
-    classNames: ['logo-card'],
-    ariaLabel: "McFatty's logo",
-    span: false,
-    template: `
-      <div class="drag-handle" aria-label="Drag to reorder"><span></span><span></span><span></span></div>
-      <button class="close-btn" aria-label="Finish organizing">&times;</button>
-      <div class="logo-card-inner">
-        <img src="Logo.png" alt="McFatty's Food Tracker logo">
-      </div>
-    `
-  },
-  {
-    id: 'manifesto',
-    elementId: 'manifesto-card',
-    classNames: ['logo-card'],
-    ariaLabel: "McFatty's Manifesto",
-    span: false,
-    template: `
-      <div class="drag-handle" aria-label="Drag to reorder"><span></span><span></span><span></span></div>
-      <button class="close-btn" aria-label="Finish organizing">&times;</button>
-      <div class="logo-card-inner">
-        <img src="manifesto.png" alt="McFatty's Manifesto logo">
-      </div>
-    `
-  },
-  {
-    id: 'support',
-    elementId: 'support-card',
-    classNames: [],
-    ariaLabelledBy: 'support-title',
-    span: false,
-    template: `
-      <div class="drag-handle" aria-label="Drag to reorder"><span></span><span></span><span></span></div>
-      <button class="close-btn" aria-label="Finish organizing">&times;</button>
-      <svg class="icon" style="width: 48px; height: 48px; margin-bottom: 8px;" viewBox="0 0 24 24"><path fill="currentColor" d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>
-      <h2 id="support-title" data-i18n="supportTitle" style="font-size: var(--fs-18); margin: 0;">Support Us</h2>
-      <p data-i18n="supportCopy" style="font-size: 13px; color: var(--text-1); margin: 4px 0 0;">If you find this app useful, please consider a small donation.</p>
-    `
-  },
-  {
-    id: 'welcome',
-    elementId: 'welcome-section',
-    classNames: [],
-    ariaLabelledBy: 'welcome-message',
-    span: false,
-    template: `
-      <div class="drag-handle" aria-label="Drag to reorder"><span></span><span></span><span></span></div>
-      <button class="close-btn" aria-label="Finish organizing">&times;</button>
-      <h2 id="welcome-message" data-i18n="welcome"></h2>
-    `
-  },
-  {
-    id: 'growth',
-    elementId: 'growth-section',
-    classNames: [],
-    ariaLabelledBy: 'growth-title',
-    span: false,
-    template: `
-      <div class="drag-handle" aria-label="Drag to reorder"><span></span><span></span><span></span></div>
-      <button class="close-btn" aria-label="Finish organizing">&times;</button>
-      <h2 id="growth-title" data-i18n="growthTitle">Room to grow</h2>
-      <p data-i18n="growthCopy">This space is ready for habits, reflections, or whatever else you need next.</p>
-    `
-  },
-  {
-    id: 'support',
-    elementId: 'support-card',
-    classNames: ['support-card'],
-    ariaLabelledBy: 'support-title',
-    span: false,
-    template: `
-      <div class="drag-handle" aria-label="Drag to reorder"><span></span><span></span><span></span></div>
-      <button class="close-btn" aria-label="Finish organizing">&times;</button>
-      <div class="support-card-inner">
-        <span class="support-badge" data-i18n="supportBadge">Keep McFatty’s free</span>
-        <h2 id="support-title" data-i18n="supportTitle">Support us</h2>
-        <p class="support-copy" data-i18n="supportCopy">Chip in to cover hosting and keep the tracker open for everyone.</p>
-        <button id="support-button" class="btn btn-primary" type="button" data-i18n="donateBtn">Donate</button>
-      </div>
-    `
-  },
-  {
-    id: 'stats',
-    elementId: 'stats-section',
-    classNames: ['span-2'],
-    ariaLabelledBy: 'quick-stats-title',
-    span: true,
-    template: `
-      <div class="drag-handle" aria-label="Drag to reorder"><span></span><span></span><span></span></div>
-      <button class="close-btn" aria-label="Finish organizing">&times;</button>
-      <h2 id="quick-stats-title" data-i18n="quickStatsTitle">Quick stats</h2>
-      <div class="quick-stats-grid">
-        <div class="stat-card">
-          <span class="stat-label" data-i18n="statEntriesToday">Entries today</span>
-          <div id="stat-total" class="stat-value">0</div>
-        </div>
-        <div class="stat-card">
-          <span class="stat-label" data-i18n="statDairyToday">Dairy items</span>
-          <div id="stat-dairy" class="stat-value">0</div>
-        </div>
-        <div class="stat-card">
-          <span class="stat-label" data-i18n="statOutsideMeals">Outside of mealtimes</span>
-          <div id="stat-outside" class="stat-value">0</div>
-        </div>
-        <div class="stat-card">
-          <span class="stat-label" data-i18n="statLastEntry">Last entry</span>
-          <div id="stat-last" class="stat-value" aria-live="polite">—</div>
-          <div id="stat-last-subtext" class="stat-subtext"></div>
-        </div>
-      </div>
-    `
-  },
-  {
-    id: 'quick-add',
-    elementId: 'add-item-section',
-    classNames: ['span-2'],
-    ariaLabelledBy: 'addItem',
-    span: true,
-    template: `
-      <div class="drag-handle" aria-label="Drag to reorder"><span></span><span></span><span></span></div>
-      <button class="close-btn" aria-label="Finish organizing">&times;</button>
-      <h2 id="addItem" data-i18n="quickAddTitle">Quick add</h2>
-      <p class="quick-add-subtext" data-i18n="quickAddHint">Log what you’re eating right now—no pressure, no judgement.</p>
-      <div class="quick-add-body">
-        <div>
-          <label for="food-name" class="label" data-i18n="foodLabel">Food item name</label>
-          <input id="food-name" class="input" type="text" placeholder="e.g., Cheeseburger" data-i18n-placeholder="foodPlaceholder">
-        </div>
-        <div class="quick-add-actions">
-          <label style="display:flex;align-items:center;gap:var(--sp-8);margin:0;">
-            <input id="contains-dairy" type="checkbox" class="checkbox" aria-label="Contains dairy">
-            <span data-i18n="dairyLabel">Contains dairy</span>
-          </label>
-          <label style="display:flex;align-items:center;gap:var(--sp-8);margin:0;">
-            <input id="outside-meals" type="checkbox" class="checkbox" aria-label="Outside of mealtimes">
-            <span data-i18n="outsideMealsLabel">Outside of mealtimes</span>
-          </label>
-          <button id="add-button" class="btn btn-primary" type="button" data-i18n="addBtn">Add to log</button>
-        </div>
-      </div>
-    `
-  },
-  {
-    id: 'recent-log',
-    elementId: 'log-section',
-    classNames: ['span-2'],
-    ariaLabelledBy: 'recentLog',
-    span: true,
-    template: `
-      <div class="drag-handle" aria-label="Drag to reorder"><span></span><span></span><span></span></div>
-      <button class="close-btn" aria-label="Finish organizing">&times;</button>
-      <div class="section-head">
-        <h2 id="recentLog" data-i18n="recentLogTitle">Recent log</h2>
-        <button id="export-button" class="btn btn-secondary" type="button" data-i18n="exportBtn">Export</button>
-      </div>
-      <div class="log-controls" role="search">
-        <div class="log-search">
-          <label class="sr-only" for="log-search" data-i18n="logSearchLabel">Search log</label>
-          <input id="log-search" class="input" type="search" placeholder="Search entries" data-i18n-placeholder="logSearchPlaceholder">
-        </div>
-        <div class="filter-group" role="group" aria-labelledby="log-filters-label">
-          <span id="log-filters-label" class="sr-only" data-i18n="filterGroupLabel">Filters</span>
-          <button type="button" class="filter-btn is-active" data-filter="all" data-i18n="filterAll">All</button>
-          <button type="button" class="filter-btn" data-filter="dairy" data-i18n="filterDairy">Dairy</button>
-          <button type="button" class="filter-btn" data-filter="non-dairy" data-i18n="filterNonDairy">No dairy</button>
-          <button type="button" class="filter-btn" data-filter="outside-meals" data-i18n="filterOutsideMeals">Outside of mealtimes</button>
-          <button type="button" class="filter-btn" data-filter="during-meals" data-i18n="filterMeals">At mealtimes</button>
-        </div>
-      </div>
-      <table class="table" aria-describedby="recentLog">
-        <thead>
-          <tr>
-            <th data-i18n="thItem">Item</th>
-            <th data-i18n="thTime">Time</th>
-            <th data-i18n="thDairy">Dairy</th>
-            <th data-i18n="thOutsideMeals">Outside of mealtimes</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody id="log-body"></tbody>
-      </table>
-      <div id="empty-state" class="info-text" style="display:none" data-i18n="emptyState">No items yet. Add your first item above.</div>
-      <div id="no-results" class="info-text" style="display:none" data-i18n="noResults">No entries match your filters yet.</div>
-    `
-  }
+import logoTile from './tiles/logo.js';
+import manifestoTile from './tiles/manifesto.js';
+import welcomeTile from './tiles/welcome.js';
+import growthTile from './tiles/growth.js';
+import supportTile from './tiles/support.js';
+import statsTile from './tiles/stats.js';
+import quickAddTile from './tiles/quick-add.js';
+import recentLogTile from './tiles/recent-log.js';
+
+// To add or remove tiles, create or delete a file in js/tiles and update this list.
+export const tileDefinitions = [
+  logoTile,
+  manifestoTile,
+  welcomeTile,
+  growthTile,
+  supportTile,
+  statsTile,
+  quickAddTile,
+  recentLogTile
 ];
 
 let containerRef = null;
@@ -615,4 +445,4 @@ export function initTileSystem({ container, reorderToggle, reorderHint, getTrans
     refreshLabels: updateReorderTexts,
     isReorganizeMode: () => isReorganizeMode
   };
-    }
+}

--- a/js/tiles/growth.js
+++ b/js/tiles/growth.js
@@ -1,0 +1,15 @@
+const growthTile = {
+  id: 'growth',
+  elementId: 'growth-section',
+  classNames: [],
+  ariaLabelledBy: 'growth-title',
+  span: false,
+  template: `
+      <div class="drag-handle" aria-label="Drag to reorder"><span></span><span></span><span></span></div>
+      <button class="close-btn" aria-label="Finish organizing">&times;</button>
+      <h2 id="growth-title" data-i18n="growthTitle">Room to grow</h2>
+      <p data-i18n="growthCopy">This space is ready for habits, reflections, or whatever else you need next.</p>
+    `
+};
+
+export default growthTile;

--- a/js/tiles/logo.js
+++ b/js/tiles/logo.js
@@ -1,0 +1,16 @@
+const logoTile = {
+  id: 'logo',
+  elementId: 'logo-card',
+  classNames: ['logo-card'],
+  ariaLabel: "McFatty's logo",
+  span: false,
+  template: `
+      <div class="drag-handle" aria-label="Drag to reorder"><span></span><span></span><span></span></div>
+      <button class="close-btn" aria-label="Finish organizing">&times;</button>
+      <div class="logo-card-inner">
+        <img src="Logo.png" alt="McFatty's Food Tracker logo">
+      </div>
+    `
+};
+
+export default logoTile;

--- a/js/tiles/manifesto.js
+++ b/js/tiles/manifesto.js
@@ -1,0 +1,16 @@
+const manifestoTile = {
+  id: 'manifesto',
+  elementId: 'manifesto-card',
+  classNames: ['logo-card'],
+  ariaLabel: "McFatty's Manifesto",
+  span: false,
+  template: `
+      <div class="drag-handle" aria-label="Drag to reorder"><span></span><span></span><span></span></div>
+      <button class="close-btn" aria-label="Finish organizing">&times;</button>
+      <div class="logo-card-inner">
+        <img src="manifesto.png" alt="McFatty's Manifesto logo">
+      </div>
+    `
+};
+
+export default manifestoTile;

--- a/js/tiles/quick-add.js
+++ b/js/tiles/quick-add.js
@@ -1,0 +1,32 @@
+const quickAddTile = {
+  id: 'quick-add',
+  elementId: 'add-item-section',
+  classNames: ['span-2'],
+  ariaLabelledBy: 'addItem',
+  span: true,
+  template: `
+      <div class="drag-handle" aria-label="Drag to reorder"><span></span><span></span><span></span></div>
+      <button class="close-btn" aria-label="Finish organizing">&times;</button>
+      <h2 id="addItem" data-i18n="quickAddTitle">Quick add</h2>
+      <p class="quick-add-subtext" data-i18n="quickAddHint">Log what you’re eating right now—no pressure, no judgement.</p>
+      <div class="quick-add-body">
+        <div>
+          <label for="food-name" class="label" data-i18n="foodLabel">Food item name</label>
+          <input id="food-name" class="input" type="text" placeholder="e.g., Cheeseburger" data-i18n-placeholder="foodPlaceholder">
+        </div>
+        <div class="quick-add-actions">
+          <label style="display:flex;align-items:center;gap:var(--sp-8);margin:0;">
+            <input id="contains-dairy" type="checkbox" class="checkbox" aria-label="Contains dairy">
+            <span data-i18n="dairyLabel">Contains dairy</span>
+          </label>
+          <label style="display:flex;align-items:center;gap:var(--sp-8);margin:0;">
+            <input id="outside-meals" type="checkbox" class="checkbox" aria-label="Outside of mealtimes">
+            <span data-i18n="outsideMealsLabel">Outside of mealtimes</span>
+          </label>
+          <button id="add-button" class="btn btn-primary" type="button" data-i18n="addBtn">Add to log</button>
+        </div>
+      </div>
+    `
+};
+
+export default quickAddTile;

--- a/js/tiles/recent-log.js
+++ b/js/tiles/recent-log.js
@@ -1,0 +1,45 @@
+const recentLogTile = {
+  id: 'recent-log',
+  elementId: 'log-section',
+  classNames: ['span-2'],
+  ariaLabelledBy: 'recentLog',
+  span: true,
+  template: `
+      <div class="drag-handle" aria-label="Drag to reorder"><span></span><span></span><span></span></div>
+      <button class="close-btn" aria-label="Finish organizing">&times;</button>
+      <div class="section-head">
+        <h2 id="recentLog" data-i18n="recentLogTitle">Recent log</h2>
+        <button id="export-button" class="btn btn-secondary" type="button" data-i18n="exportBtn">Export</button>
+      </div>
+      <div class="log-controls" role="search">
+        <div class="log-search">
+          <label class="sr-only" for="log-search" data-i18n="logSearchLabel">Search log</label>
+          <input id="log-search" class="input" type="search" placeholder="Search entries" data-i18n-placeholder="logSearchPlaceholder">
+        </div>
+        <div class="filter-group" role="group" aria-labelledby="log-filters-label">
+          <span id="log-filters-label" class="sr-only" data-i18n="filterGroupLabel">Filters</span>
+          <button type="button" class="filter-btn is-active" data-filter="all" data-i18n="filterAll">All</button>
+          <button type="button" class="filter-btn" data-filter="dairy" data-i18n="filterDairy">Dairy</button>
+          <button type="button" class="filter-btn" data-filter="non-dairy" data-i18n="filterNonDairy">No dairy</button>
+          <button type="button" class="filter-btn" data-filter="outside-meals" data-i18n="filterOutsideMeals">Outside of mealtimes</button>
+          <button type="button" class="filter-btn" data-filter="during-meals" data-i18n="filterMeals">At mealtimes</button>
+        </div>
+      </div>
+      <table class="table" aria-describedby="recentLog">
+        <thead>
+          <tr>
+            <th data-i18n="thItem">Item</th>
+            <th data-i18n="thTime">Time</th>
+            <th data-i18n="thDairy">Dairy</th>
+            <th data-i18n="thOutsideMeals">Outside of mealtimes</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody id="log-body"></tbody>
+      </table>
+      <div id="empty-state" class="info-text" style="display:none" data-i18n="emptyState">No items yet. Add your first item above.</div>
+      <div id="no-results" class="info-text" style="display:none" data-i18n="noResults">No entries match your filters yet.</div>
+    `
+};
+
+export default recentLogTile;

--- a/js/tiles/stats.js
+++ b/js/tiles/stats.js
@@ -1,0 +1,33 @@
+const statsTile = {
+  id: 'stats',
+  elementId: 'stats-section',
+  classNames: ['span-2'],
+  ariaLabelledBy: 'quick-stats-title',
+  span: true,
+  template: `
+      <div class="drag-handle" aria-label="Drag to reorder"><span></span><span></span><span></span></div>
+      <button class="close-btn" aria-label="Finish organizing">&times;</button>
+      <h2 id="quick-stats-title" data-i18n="quickStatsTitle">Quick stats</h2>
+      <div class="quick-stats-grid">
+        <div class="stat-card">
+          <span class="stat-label" data-i18n="statEntriesToday">Entries today</span>
+          <div id="stat-total" class="stat-value">0</div>
+        </div>
+        <div class="stat-card">
+          <span class="stat-label" data-i18n="statDairyToday">Dairy items</span>
+          <div id="stat-dairy" class="stat-value">0</div>
+        </div>
+        <div class="stat-card">
+          <span class="stat-label" data-i18n="statOutsideMeals">Outside of mealtimes</span>
+          <div id="stat-outside" class="stat-value">0</div>
+        </div>
+        <div class="stat-card">
+          <span class="stat-label" data-i18n="statLastEntry">Last entry</span>
+          <div id="stat-last" class="stat-value" aria-live="polite">—</div>
+          <div id="stat-last-subtext" class="stat-subtext"></div>
+        </div>
+      </div>
+    `
+};
+
+export default statsTile;

--- a/js/tiles/support.js
+++ b/js/tiles/support.js
@@ -1,0 +1,19 @@
+const supportTile = {
+  id: 'support',
+  elementId: 'support-card',
+  classNames: ['support-card'],
+  ariaLabelledBy: 'support-title',
+  span: false,
+  template: `
+      <div class="drag-handle" aria-label="Drag to reorder"><span></span><span></span><span></span></div>
+      <button class="close-btn" aria-label="Finish organizing">&times;</button>
+      <div class="support-card-inner">
+        <span class="support-badge" data-i18n="supportBadge">Keep McFatty’s free</span>
+        <h2 id="support-title" data-i18n="supportTitle">Support us</h2>
+        <p class="support-copy" data-i18n="supportCopy">Chip in to cover hosting and keep the tracker open for everyone.</p>
+        <button id="support-button" class="btn btn-primary" type="button" data-i18n="donateBtn">Donate</button>
+      </div>
+    `
+};
+
+export default supportTile;

--- a/js/tiles/welcome.js
+++ b/js/tiles/welcome.js
@@ -1,0 +1,14 @@
+const welcomeTile = {
+  id: 'welcome',
+  elementId: 'welcome-section',
+  classNames: [],
+  ariaLabelledBy: 'welcome-message',
+  span: false,
+  template: `
+      <div class="drag-handle" aria-label="Drag to reorder"><span></span><span></span><span></span></div>
+      <button class="close-btn" aria-label="Finish organizing">&times;</button>
+      <h2 id="welcome-message" data-i18n="welcome"></h2>
+    `
+};
+
+export default welcomeTile;


### PR DESCRIPTION
## Summary
- split each dashboard tile into its own module under js/tiles for easier maintenance
- export the shared tile list from tiles.js and document how to add or remove entries

## Testing
- Not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d628745934832c93b22f8f4f3cdb51